### PR TITLE
Bugfix: Pressing delete on token leaves HUD intact.

### DIFF
--- a/scripts/paranoia.js
+++ b/scripts/paranoia.js
@@ -366,6 +366,10 @@ Hooks.once("ready", async function () {
         }
     });
 
+    Hooks.on("destroyToken", (token) => {
+        token_HUD.remove_hud(token);
+    });
+
     Hooks.on("renderChatMessage", (app, html, messageData) => {
         /*
         Used to hook the spend moxie to re-roll button


### PR DESCRIPTION
Hi!
I found a bug where hovering your mouse over a token, selecting it, and pressing delete means the token's still there.

I just added the relevant fix to paranoia.js, let me know if this helps any.